### PR TITLE
fix: parse files with classic Mac (CR-only) line endings

### DIFF
--- a/scripts/setup-test-data.sh
+++ b/scripts/setup-test-data.sh
@@ -233,7 +233,7 @@ echo "✅ Test delimiter fixtures created successfully"
 # spectrometer/beamline export software (regression test for parsing failures
 # on such files, which previously collapsed to a single garbled row)
 echo "📊 Creating CR-only line-ending test fixture..."
-printf 'energy_eV\tintensity\n700.0\t0.05\n700.5\t0.12\n701.0\t0.31\n701.5\t0.80\n702.0\t1.00\n702.5\t0.78\n703.0\t0.29\n703.5\t0.11\n' | tr '\n' '\r' > "$TEST_DATA_DIR/cr-line-endings-pseudo-rixs.dat"
+printf 'energy_eV\tintensity\n700.0\t0.05\n700.5\t0.12\n701.0\t0.31\n701.5\t0.80\n702.0\t1.00\n702.5\t0.78\n703.0\t0.29\n703.5\t0.11\n' | tr '\n' '\r' > "$TEST_DATA_DIR/cr-line-endings-pseudo-l-edge.dat"
 echo "✅ CR-only line-ending test fixture created successfully"
 
 # Create test files with comments for comment handling tests
@@ -317,7 +317,7 @@ echo "  - csv-with-comments.csv: CSV with comment lines (comment handling tests)
 echo "  - txt-with-comments.txt: TXT with hash comments (comment handling tests)"
 echo "  - dat-with-comments.dat: DAT with multiple comment markers (comment handling tests)"
 echo "  - custom-comment-markers.txt: File for custom comment marker tests"
-echo "  - cr-line-endings-pseudo-rixs.dat: Classic Mac (CR-only) line-ending regression test"
+echo "  - cr-line-endings-pseudo-l-edge.dat: Classic Mac (CR-only) line-ending regression test"
 echo "  - scatter-numeric-regression.csv: Regression test for issue #30 (numeric X-axis scatter plots)"
 echo ""
 echo "⚠️  IMPORTANT: Run this script before running tests locally!"

--- a/scripts/setup-test-data.sh
+++ b/scripts/setup-test-data.sh
@@ -229,6 +229,13 @@ gamma
 EOF
 echo "✅ Test delimiter fixtures created successfully"
 
+# Create a fixture with classic Mac (CR-only) line endings, as emitted by some
+# spectrometer/beamline export software (regression test for parsing failures
+# on such files, which previously collapsed to a single garbled row)
+echo "📊 Creating CR-only line-ending test fixture..."
+printf 'energy_eV\tintensity\n700.0\t0.05\n700.5\t0.12\n701.0\t0.31\n701.5\t0.80\n702.0\t1.00\n702.5\t0.78\n703.0\t0.29\n703.5\t0.11\n' | tr '\n' '\r' > "$TEST_DATA_DIR/cr-line-endings-pseudo-rixs.dat"
+echo "✅ CR-only line-ending test fixture created successfully"
+
 # Create test files with comments for comment handling tests
 echo "📊 Creating comment handling test fixtures..."
 cat > "$TEST_DATA_DIR/csv-with-comments.csv" << 'EOF'
@@ -310,6 +317,7 @@ echo "  - csv-with-comments.csv: CSV with comment lines (comment handling tests)
 echo "  - txt-with-comments.txt: TXT with hash comments (comment handling tests)"
 echo "  - dat-with-comments.dat: DAT with multiple comment markers (comment handling tests)"
 echo "  - custom-comment-markers.txt: File for custom comment marker tests"
+echo "  - cr-line-endings-pseudo-rixs.dat: Classic Mac (CR-only) line-ending regression test"
 echo "  - scatter-numeric-regression.csv: Regression test for issue #30 (numeric X-axis scatter plots)"
 echo ""
 echo "⚠️  IMPORTANT: Run this script before running tests locally!"

--- a/src/data/load.ts
+++ b/src/data/load.ts
@@ -80,6 +80,19 @@ export async function parseDataFile(
 }
 
 /**
+ * Split file content into lines, tolerating CRLF and lone-CR (classic Mac)
+ * line endings in addition to LF. Some instrument export software (e.g.
+ * older spectrometer/beamline tools) still emits bare `\r` line endings,
+ * which `String.split("\n")` alone would treat as a single line.
+ *
+ * @param content - Raw file content
+ * @returns Array of lines with line-ending characters removed
+ */
+function splitLines(content: string): string[] {
+	return content.split(/\r\n|\r|\n/);
+}
+
+/**
  * Check if a line is a comment based on configured comment markers
  *
  * @param line - Line to check
@@ -134,7 +147,7 @@ function parseCSV(
 	fileName: string,
 	commentMarkers: string[] = ["#", "%", "//"],
 ): ParsedData {
-	const lines = content.trim().split("\n");
+	const lines = splitLines(content.trim());
 	if (lines.length === 0) {
 		throw new Error("File is empty");
 	}
@@ -292,7 +305,7 @@ function parseDelimited(
 	overrideDelimiter?: string,
 	commentMarkers: string[] = ["#", "%", "//"],
 ): ParsedData {
-	const lines = content.trim().split("\n");
+	const lines = splitLines(content.trim());
 	if (lines.length === 0) {
 		throw new Error("File is empty");
 	}

--- a/src/test/delimiter.test.ts
+++ b/src/test/delimiter.test.ts
@@ -40,6 +40,27 @@ suite("Delimiter Detection Tests", () => {
 		assert.strictEqual(data?.rows.length, 3, "Should have 3 data rows");
 	});
 
+	test("Handles classic Mac (CR-only) line endings", async function () {
+		this.timeout(10000);
+		const uri = vscode.Uri.file(
+			path.join(__dirname, "../../test-data/cr-line-endings-pseudo-rixs.dat"),
+		);
+		const data = await parseDataFile(uri);
+
+		assert.ok(data, "Data should be parsed");
+		assert.strictEqual(data?.detectedDelimiter, "\t", "Should detect tab delimiter");
+		assert.strictEqual(data?.headers.length, 2, "Should have 2 columns");
+		assert.strictEqual(data?.headers[0], "energy_eV", "First header should be 'energy_eV'");
+		assert.strictEqual(data?.headers[1], "intensity", "Second header should be 'intensity'");
+		assert.strictEqual(data?.rows.length, 8, "Should have 8 data rows, not 1 garbled row");
+		assert.strictEqual(data?.rows[0][0], 700.0, "First row energy should parse as a clean number");
+		assert.strictEqual(
+			data?.rows[0][1],
+			0.05,
+			"First row intensity should parse as a clean number",
+		);
+	});
+
 	test("Handles single column with fallback", async function () {
 		this.timeout(10000);
 		const tmpPath = path.join(__dirname, "../../test-data/single-column.txt");

--- a/src/test/delimiter.test.ts
+++ b/src/test/delimiter.test.ts
@@ -43,7 +43,7 @@ suite("Delimiter Detection Tests", () => {
 	test("Handles classic Mac (CR-only) line endings", async function () {
 		this.timeout(10000);
 		const uri = vscode.Uri.file(
-			path.join(__dirname, "../../test-data/cr-line-endings-pseudo-rixs.dat"),
+			path.join(__dirname, "../../test-data/cr-line-endings-pseudo-l-edge.dat"),
 		);
 		const data = await parseDataFile(uri);
 

--- a/src/test/edgecases.test.ts
+++ b/src/test/edgecases.test.ts
@@ -176,7 +176,7 @@ suite("Edge Cases and Robustness Tests", () => {
 		assert.strictEqual(data?.headers.length, 3, "Should have 3 columns");
 		assert.strictEqual(data?.rows.length, 2, "Should have 2 data rows");
 		assert.strictEqual(
-			(data?.rows[0][0] as string).length,
+			(data.rows[0][0] as string).length,
 			1000,
 			"First cell should have 1000 characters",
 		);


### PR DESCRIPTION
## Summary
- Some instrument export software (e.g. spectrometer/beamline tools) emits bare `\r` line endings with no `\n`. The CSV/delimited parsers in `src/data/load.ts` split content on `"\n"` only, so such files collapsed into a single garbled line, with values glued together across record boundaries instead of clean rows — making them unparseable/unplottable. (Triggered by a real Fe L-edge XAS spectrum exported with classic Mac CR-only line endings.)
- Added a `splitLines()` helper that tolerates LF, CRLF, and lone-CR line endings, used by both `parseCSV` and `parseDelimited`.
- Added a synthetic CR-only pseudo-L-edge fixture (generated via `scripts/setup-test-data.sh`, following this repo's existing convention of not committing `test-data/` fixtures) and a regression test in `src/test/delimiter.test.ts`.
- Also fixes an unrelated `noUnsafeOptionalChaining` error in `src/test/edgecases.test.ts` that CI's `biome ci` (latest) flags but the locally pinned biome version (2.4.10) only warns on — this was blocking the CI check on this branch regardless of the parsing fix.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run pretest` (compile + lint) passes clean for the changed files
- [x] `npx @biomejs/biome@latest ci src/` and `ci scripts/` both exit 0 (matching the CI job exactly)
- [x] Verified the fix directly against the compiled module (stubbing `vscode`) — a real-world CR-only L-edge spectrum file now parses into clean rows instead of one garbled row
- [x] Verified existing LF-based fixtures (colon/pipe/space-delimited, csv-with-comments) still parse identically — no regression
- [ ] Full `vscode-test` Electron suite could not be run in this environment (stale/mismatched local VS Code test host download, unrelated to this change) — recommend CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZTVYD3cKXPgFJx6qSwZoc